### PR TITLE
Convert coverage to lcov

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,6 @@ updates:
       - "@me"
     assignees:
       - "@me"
-    commit-message:
-      prefix: "deps"
-      include: "scope"
 
   # Monitor GitHub Actions workflows
   - package-ecosystem: "github-actions"
@@ -22,6 +19,3 @@ updates:
       - "@me"
     assignees:
       - "@me"
-    commit-message:
-      prefix: "ci"
-      include: "scope"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,13 +36,17 @@ jobs:
       run: swift test --parallel
       
     - name: Generate test report
-      if: always()
-      run: swift test --parallel --enable-code-coverage
-      
+      run: |
+        brew install llvm lcov
+        swift test --parallel --enable-code-coverage
+        mkdir -p .build/debug/codecov
+        llvm-cov export -format=lcov .build/debug/DBusPackageTests.xctest/Contents/MacOS/DBusPackageTests -instr-profile .build/debug/codecov/default.profdata > .build/debug/codecov/lcov_raw.info
+        # Filter out checkouts and other unwanted paths
+        lcov --remove .build/debug/codecov/lcov_raw.info '*/.build/*' '*/Tests/*' --output-file .build/debug/codecov/lcov.info
+        
     - name: Upload coverage to Coveralls
-      if: always()
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-lcov: .build/debug/codecov/lcov.info
+        file: .build/debug/codecov/lcov.info
         fail-on-error: false 

--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,4 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [DBus]


### PR DESCRIPTION
- Add a step to the unit test workflow to convert the coverage report to lcov format
- Drop the commit-message dictionary from dependabot config
- Add a Swift Package Index DocC configuration file